### PR TITLE
fix(index): add local nvim to workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Plug 'folke/lua-dev.nvim'
     vimruntime = true, -- runtime path
     types = true, -- full signature, docs and completion of vim.api, vim.treesitter, vim.lsp and others
     plugins = true, -- installed opt or start plugins in packpath
+    nvim_cfg = true, -- index local nvim cfg
     -- you can also specify the list of plugins to make available as a workspace library
     -- plugins = { "nvim-treesitter", "plenary.nvim", "telescope.nvim" },
   },

--- a/lua/lua-dev/config.lua
+++ b/lua/lua-dev/config.lua
@@ -7,6 +7,7 @@ M.defaults = {
     vimruntime = true, -- runtime path
     types = true, -- full signature, docs and completion of vim.api, vim.treesitter, vim.lsp and others
     plugins = true, -- installed opt or start plugins in packpath
+    nvim_cfg = true, -- index local nvim cfg
     -- you can also specify the list of plugins to make available as a workspace library
     -- plugins = { "nvim-treesitter", "plenary.nvim", "telescope.nvim" },
   },

--- a/lua/lua-dev/sumneko.lua
+++ b/lua/lua-dev/sumneko.lua
@@ -23,6 +23,10 @@ function M.library(opts)
     add("$VIMRUNTIME")
   end
 
+  if opts.library.nvim_cfg then
+    add("$HOME/.config/nvim")
+  end
+
   if opts.library.plugins then
     local filter
     if type(opts.library.plugins) == "table" then


### PR DESCRIPTION
Signed-off-by: Daniel Nehrig <daniel.nehrig@dnehrig.com>

only adding the local nvim config to the workspace like this allows me to jump to definitions
i'm not sure if i'm the only one with this problem but this is the only way to make it working for me.

if i use the current behaviour jump to def does not work
only if the file was already opened

it looks like my .config/nvim folder does not get indexed
adding it to the workspace solved my problem