### PR TITLE
Make additional config paths configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Plug 'folke/lua-dev.nvim'
     -- disable other plugins by default
     plugins = false,
   },
+  additional_config_paths = {}, -- additional paths to enable this plugin in. e.g. /etc/nixos/ on NixOS
 }
 ```
 
@@ -68,6 +69,7 @@ Plug 'folke/lua-dev.nvim'
 
 * your Neovim config directory
 * any plugin directory (this is an lsp root_dir that contains a `/lua` directory)
+* any directory listed in `additional_config_paths`
 
 For any other `root_dir`, **lua-dev** will **NOT** change any settings.
 

--- a/lua/lua-dev/config.lua
+++ b/lua/lua-dev/config.lua
@@ -17,6 +17,7 @@ M.defaults = {
     -- disable other plugins by default
     plugins = false,
   },
+  additional_config_paths = {},
 }
 
 --- @type LuaApiOptions

--- a/lua/lua-dev/lsp.lua
+++ b/lua/lua-dev/lsp.lua
@@ -22,6 +22,14 @@ function M.on_new_config(config, root_dir)
 
   local enabled = util.is_nvim_config(root_dir)
 
+  if not enabled then
+    for _, path in pairs(opts.additional_config_paths) do
+      if util.fqn(path) == root_dir then
+        enabled = true
+      end
+    end
+  end
+
   if not enabled and util.is_plugin(root_dir) then
     enabled = true
     opts.library = opts.plugin_library


### PR DESCRIPTION
My usecase for this is that I am on NixOS and manage all my configs trough it. Concretly that means that an editable version of my neovim config lives at `/etc/nixos/config/nvim` (see also my [dotfiles](https://codeberg.org/b4rc1/dotfiles)) but during runtime an immutable copy is symlinked to `~/.config/nvim`. Currently there is no way to get this plugins functionality in `/etc/nixos` (You could create an empty `/etc/nixos/lua` directory, but thats more of a hack than a solution)

This PR enables one to configure additional paths to be considered neovim config dirs in the setup function of this plugin like so:
```lua
require("lua-dev").setup({
  -- ...
  additional_config_paths = { "/etc/nixos/" }
})
```

This could also be useful for people using stow and git to manage their dotfiles.
