### PR TITLE
fix: improve typing for scoped variables

### DIFF
--- a/types/nightly/vim.lua
+++ b/types/nightly/vim.lua
@@ -32,9 +32,14 @@ vim.lpeg = require("lpeg")
 vim.g = {}
 ---@type table<string,any>
 vim.v = {}
----@type table<number,table<string, any>>
+
+---@class ScopedVariables
+---@field [number] table<string, any>
+---@field [string] any
+
+---@type ScopedVariables
 vim.b = {}
----@type table<number,table<string, any>>
+---@type ScopedVariables
 vim.w = {}
----@type table<number,table<string, any>>
+---@type ScopedVariables
 vim.t = {}

--- a/types/stable/vim.lua
+++ b/types/stable/vim.lua
@@ -32,9 +32,14 @@ vim.lpeg = require("lpeg")
 vim.g = {}
 ---@type table<string,any>
 vim.v = {}
----@type table<number,table<string, any>>
+
+---@class ScopedVariables
+---@field [number] table<string, any>
+---@field [string] any
+
+---@type ScopedVariables
 vim.b = {}
----@type table<number,table<string, any>>
+---@type ScopedVariables
 vim.w = {}
----@type table<number,table<string, any>>
+---@type ScopedVariables
 vim.t = {}


### PR DESCRIPTION
Problem:

Seeing diagnostic warnings about undefined field when accessing window/buffer/tab scoped variables

```lua
vim.w.my_window_var   -- Undefined field `my_window_var`.
```

Solution:

More correct type definition for `vim.b/w/t` that accounts for the raw (non-numeric) variable access. This uses the `@field` annotation syntax to describe all keys of a certain type ([detailed here](https://luals.github.io/wiki/annotations/#field))