### PR TITLE
implement opts.library.blacklist (#148)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Plug 'folke/neodev.nvim'
     plugins = true, -- installed opt or start plugins in packpath
     -- you can also specify the list of plugins to make available as a workspace library
     -- plugins = { "nvim-treesitter", "plenary.nvim", "telescope.nvim" },
+    blacklist = {}, -- opposite of plugins list, neodev will not make these available as a workspace library
+    -- blacklist = { "nvim-treesitter", "plenary.nvim", "telescope.nvim" },
   },
   setup_jsonls = true, -- configures jsonls to provide completion for project specific .luarc.json files
   -- for your Neovim config directory, the config.library settings will be used as is

--- a/lua/neodev/config.lua
+++ b/lua/neodev/config.lua
@@ -11,6 +11,9 @@ M.defaults = {
     plugins = true, -- installed opt or start plugins in packpath
     -- you can also specify the list of plugins to make available as a workspace library
     -- plugins = { "nvim-treesitter", "plenary.nvim", "telescope.nvim" },
+    ---@type string[]
+    blacklist = {}, -- opposite of plugins list, neodev will not make these available as a workspace library
+    -- blacklist = { "nvim-treesitter", "plenary.nvim", "telescope.nvim" },
   },
   setup_jsonls = true, -- configures jsonls to provide completion for .luarc.json files
   -- for your neovim config directory, the config.library settings will be used as is

--- a/lua/neodev/luals.lua
+++ b/lua/neodev/luals.lua
@@ -31,7 +31,7 @@ function M.library(opts)
   end
 
   if opts.library.plugins then
-    ---@type table<string, boolean>
+    ---@type table<string, boolean>, table<string, boolean>
     local filter, blacklist
     if type(opts.library.plugins) == "table" then
       filter = {}


### PR DESCRIPTION
This PR implements #148 by adding a new option (`opts.library.blacklist`) which is a string[] that consists
of plugin names (just as `opts.library.plugins`) which will not be included in the final path.

Note: This overrides `opts.library.plugins` in that, if a plugin is included in the blacklist, it *will not*
be included, even if included in the `plugins` list.
