### PR TITLE
docs: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Plug 'folke/neodev.nvim'
   -- for your Neovim config directory, the config.library settings will be used as is
   -- for plugin directories (root_dirs having a /lua directory), config.library.plugins will be disabled
   -- for any other directory, config.library.enabled will be set to false
-  override = function(root_dir, options) end,
+  override = function(root_dir, library) end,
   -- With lspconfig, Neodev will automatically setup your lua-language-server
   -- If you disable this, then you have to set {before_init=require("neodev.lsp").before_init}
   -- in your lsp start options

--- a/lua/neodev/config.lua
+++ b/lua/neodev/config.lua
@@ -16,7 +16,7 @@ M.defaults = {
   -- for your neovim config directory, the config.library settings will be used as is
   -- for plugin directories (root_dirs having a /lua directory), config.library.plugins will be disabled
   -- for any other directory, config.library.enabled will be set to false
-  override = function(root_dir, options) end,
+  override = function(root_dir, library) end,
   -- With lspconfig, Neodev will automatically setup your lua-language-server
   -- If you disable this, then you have to set {before_init=require("neodev.lsp").before_init}
   -- in your lsp start options


### PR DESCRIPTION
Simple typo in README & comments. `opts.override`'s second argument is not `options` but `library`.