### PR TITLE
fix config.root() so it returns a string or nil

### DIFF
--- a/lua/neodev/config.lua
+++ b/lua/neodev/config.lua
@@ -41,7 +41,7 @@ end
 ---@param root? string
 function M.root(root)
   local f = debug.getinfo(1, "S").source:sub(2)
-  return vim.loop.fs_realpath(vim.fn.fnamemodify(f, ":h:h:h") .. "/" .. (root or ""))
+  return (vim.loop.fs_realpath(vim.fn.fnamemodify(f, ":h:h:h") .. "/" .. (root or "")))
 end
 
 ---@return "nightly" | "stable"


### PR DESCRIPTION
`config.root()` should return `string?`, but `vim.loop.fs_realpath` returns a 3-tuple (see :help vim.uv.fs_realpath and :help luv-error-handling). By adding parentheses around the function call, we force the function to return the first value of the tuple, which also fixes `config.types()` so it returns `string?` as well.

This fixes an error when trying to use [rocks.nvim](https://github.com/nvim-neorocks/rocks.nvim)  to install `neodev.nvim`. Since the `types/` folder is nowhere to be found when installing neodev.nvim with luarocks, the call to fs_realpath returns an error, and stops the execution after any call to `config.types()` (which happens when trying to setup library folders for the LSP. This creates a bunch of `Undefined global 'vim'` appear on my `init.lua` config.

Although this looks like a fix specifically for my use case with rocks.nvim, it makes the function comply with it's signature, which I see as a good thing in the long run.